### PR TITLE
Update Resources/doc/index.rst to fix a wrong class name

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -102,7 +102,7 @@ Enable the bundle in the kernel::
 	{
 		$bundles = array(
 			// ...
-			new NoiseLabs\Bundle\SmartyBundle(),
+			new NoiseLabs\Bundle\SmartyBundle\SmartyBundle(),
 		);
 	}
 


### PR DESCRIPTION
Mainly:

```
NoiseLabs\Bundle\SmartyBundle() => NoiseLabs\Bundle\SmartyBundle\SmartyBundle()
```

This is a small fix to the documentation. The class name to load the bundle was wrong because the namespace of the class was not specified correctly. This PR fix the problem.

I did this to help someone on stackoverflow, I did not test the rest of the documentation to check if it was accurate or not.

Regards,
Matt
