### PR TITLE
Fix for composer.json not being parsable.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/framework-bundle": ">=2.0",
-        "smarty/smarty": "v3.1.*@stable"
+        "smarty/smarty": "3.1.*@stable"
     },
     "require-dev": {
         "symfony/assetic-bundle": ">=2.0",


### PR DESCRIPTION
Allow deployment via composer by fixing version syntax.
