### PR TITLE
Add support for Expressions within templates

### DIFF
--- a/Extension/ExpressionExtension.php
+++ b/Extension/ExpressionExtension.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * This file is part of NoiseLabs-SmartyBundle
+ *
+ * NoiseLabs-SmartyBundle is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * NoiseLabs-SmartyBundle is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with NoiseLabs-SmartyBundle; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2011-2014 Vítor Brandão
+ *
+ * @category    NoiseLabs
+ * @package     SmartyBundle
+ * @copyright   (C) 2011-2014 Vítor Brandão <vitor@noiselabs.org>
+ * @license     http://www.gnu.org/licenses/lgpl-3.0-standalone.html LGPL-3
+ * @link        http://www.noiselabs.org
+ */
+
+namespace NoiseLabs\Bundle\SmartyBundle\Extension;
+
+use NoiseLabs\Bundle\SmartyBundle\Extension\Plugin\ModifierPlugin;
+use Symfony\Component\ExpressionLanguage\Expression;
+/**
+ * SmartyBundle extension for Symfony actions helper.
+ *
+ * This extension tries to provide the same functionality described in
+ * {@link http://symfony.com/doc/current/book/security.html#book-security-template-expression}.
+ *
+ * @author Matt Labrum
+ */
+class ExpressionExtension extends AbstractExtension
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPlugins()
+    {
+        return array(
+            new ModifierPlugin('expression', $this, 'createExpression'),
+        );
+    }
+
+    /**
+     * Creates an expression from a string
+     *
+     * @param string $expression A symfony expression
+     * @see Symfony\Bridge\Twig\Extension\ExpressionExtension::createExpression
+     */
+    public function createExpression($expression)
+    {
+        return new Expression($expression);
+    }
+
+    /**
+     * Returns the name of the extension.
+     *
+     * @return string The extension name
+     *
+     * @since  0.1.0
+     */
+    public function getName()
+    {
+        return 'expression';
+    }
+}

--- a/Resources/config/smarty.xml
+++ b/Resources/config/smarty.xml
@@ -14,6 +14,7 @@
         <parameter key="smarty.extension.routing.class">NoiseLabs\Bundle\SmartyBundle\Extension\RoutingExtension</parameter>
         <parameter key="smarty.extension.security.class">NoiseLabs\Bundle\SmartyBundle\Extension\SecurityExtension</parameter>
         <parameter key="smarty.extension.trans.class">NoiseLabs\Bundle\SmartyBundle\Extension\TranslationExtension</parameter>
+        <parameter key="smarty.extension.expression.class">NoiseLabs\Bundle\SmartyBundle\Extension\ExpressionExtension</parameter>
         <parameter key="smarty.templating.finder.class">NoiseLabs\Bundle\SmartyBundle\CacheWarmer\SmartyTemplateFinder</parameter>
         <parameter key="smarty.cache_warmer.class">NoiseLabs\Bundle\SmartyBundle\CacheWarmer\SmartyCacheWarmer</parameter>
     </parameters>
@@ -60,6 +61,10 @@
         <service id="smarty.extension.security" class="%smarty.extension.security.class%" public="false">
             <tag name="smarty.extension" />
             <argument type="service" id="security.context" on-invalid="ignore" />
+        </service>
+
+        <service id="smarty.extension.expression" class="%smarty.extension.expression.class%" public="false">
+            <tag name="smarty.extension" />
         </service>
 
         <service id="smarty_engine" alias="templating.engine.smarty" />


### PR DESCRIPTION
This adds support for using symfony Expressions. 

This class is pretty much a copy of https://github.com/symfony/symfony/blob/master/src/Symfony/Bridge/Twig/Extension/ExpressionExtension.php

This allows you to use expressions with the security extension http://symfony.com/doc/current/book/security.html#book-security-template-expression

``` smarty
{if '"ROLE_ADMIN" in roles or (user and user.isSuperAdmin())'|expression|is_granted }
Hi Admin!
{/if}
```
