### PR TITLE
Fix render method to allow different strategies other than ESI

### DIFF
--- a/Extension/ActionsExtension.php
+++ b/Extension/ActionsExtension.php
@@ -121,7 +121,12 @@ class ActionsExtension extends AbstractExtension
     {
         $renderOptions = array();
         if (isset($options['standalone']) && true === $options['standalone']) {
-            $renderOptions['strategy'] = 'esi';
+		if(isset($options['strategy'])){
+			$renderOptions['strategy'] = $options['strategy'];
+			unset($options['strategy']);
+		}else{
+			$renderOptions['strategy'] = 'esi';
+		}
             unset($options['standalone']);
         }
 


### PR DESCRIPTION
This pull request fixes the issue where the render method would ignore what rendering strategy you wanted and only render as ESI

``` smarty
{'Bundle:Controller:Action'|render:[]:['standalone' => true, 'strategy' => 'hinclude']}
```

would have been rendered as ESI before this fix.
