### PR TITLE
Fix #34 render tag always assumes the passed string is a controller

### DIFF
--- a/Extension/ActionsExtension.php
+++ b/Extension/ActionsExtension.php
@@ -125,9 +125,11 @@ class ActionsExtension extends AbstractExtension
             unset($options['standalone']);
         }
 
+	$isControllerReference = strpos($controller, ":") !== false;
+		
         return $this->getActionsHelper()->render(
-            $this->getActionsHelper()->controller($controller, $attributes, $options),
-            $renderOptions
+            $isControllerReference ? $this->getActionsHelper()->controller($controller, $attributes, $options) : $controller,
+            $isControllerReference ? $renderOptions : array_merge($renderOptions, $attributes)
         );
     }
 


### PR DESCRIPTION
This should fix issue #34 where the render method doesn't work with URI's.

Note: when using a uri, you pass both attributes and strategy through the first render parameter and when using a controller, you pass the strategy through the second parameter.

``` smarty
{* Using path and passing an option *}
{'route_name'|path|render:['test' => true]}

{* Using a strategy (hinclude) with the render tag using a path *}
{'route_name'|path|render:['test' => true, 'standalone' => true, 'strategy' => 'hinclude']}
```
