### PR TITLE
Bundle is not compatible with symfony/templating 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/framework-bundle": "~2.1",
-        "smarty/smarty": "3.1.*@stable"
+        "smarty/smarty": "3.1.*",
+        "symfony/templating": "~2.1"
     },
     "require-dev": {
         "symfony/security": "~2.1",
@@ -41,7 +42,6 @@
         "psr-0": { "NoiseLabs\\Bundle\\SmartyBundle": "" }
     },
     "target-dir": "NoiseLabs/Bundle/SmartyBundle",
-    "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
             "dev-master": "1.2.x-dev"


### PR DESCRIPTION
As the bundle is not compatible with symfony/templating 3 we force a lower version via composer.json