### PR TITLE
fix problem with "plugin tag are already registered" debug messages

### DIFF
--- a/Extension/Plugin/PluginInterface.php
+++ b/Extension/Plugin/PluginInterface.php
@@ -35,4 +35,14 @@ namespace NoiseLabs\Bundle\SmartyBundle\Extension\Plugin;
 interface PluginInterface
 {
     public function getType();
+
+    /**
+     * Get the plugin name.
+     */
+    public function getName();
+
+    /**
+     * Return the plugin callback.
+     */
+    public function getCallback();
 }

--- a/SmartyEngine.php
+++ b/SmartyEngine.php
@@ -58,6 +58,7 @@ class SmartyEngine implements EngineInterface
     protected $loader;
     protected $parser;
     protected $plugins;
+    protected $registeredPlugins = array();
     protected $smarty;
 
     /**
@@ -569,13 +570,21 @@ class SmartyEngine implements EngineInterface
     public function registerPlugins()
     {
         foreach ($this->getPlugins() as $plugin) {
-            try {
-                $this->smarty->registerPlugin($plugin->getType(), $plugin->getName(), $plugin->getCallback());
-            } catch (\SmartyException $e) {
-                if (null !== $this->logger) {
-                    $this->logger->debug(sprintf("SmartyException caught: %s.", $e->getMessage()));
-                }
-            }
+            $this->registerPlugin($plugin);
+        }
+    }
+
+    /**
+     * register plugin to Smarty.
+     *
+     * @return  void
+     */
+    protected function registerPlugin(PluginInterface $plugin)
+    {
+        // verify that plugin isn't registered yet. That would cause a SmartyException.
+        if (!in_array($plugin->getType() . '_' . $plugin->getName(), $this->registeredPlugins)) {
+            $this->smarty->registerPlugin($plugin->getType(), $plugin->getName(), $plugin->getCallback());
+            $this->registeredPlugins[] = $plugin->getType() . '_' . $plugin->getName();
         }
     }
 


### PR DESCRIPTION
thank you for your hard work on this great bundle.

I noticed a lot of "plugin tag already registered" debug messages on a project of mine.
The project uses the Symfony AppCache and a lot of ESI's. With every ESI render() a block of this debug messages were logged.

```
[2016-03-18 18:43:33] SmartyBundle.DEBUG: SmartyException caught: Plugin tag "path" already registered.
[2016-03-18 18:43:33] SmartyBundle.DEBUG: SmartyException caught: Plugin tag "path" already registered.
[2016-03-18 18:43:33] SmartyBundle.DEBUG: SmartyException caught: Plugin tag "url" already registered.
[2016-03-18 18:43:33] SmartyBundle.DEBUG: SmartyException caught: Plugin tag "url" already registered.
```

The debug messages are caused because the method registerPlugins() is called on the method render(). registerPlugins() registers the plugins on the Smarty instance regardless if it is already registered.

My solution is to track which plugins are already registered and skip those that are being already registered. That allows to add plugins between two or more render() calls.

I would appreciate if you could merge my pull request.

