### PR TITLE
improve "plugin already registered" verification 

### DIFF
--- a/SmartyEngine.php
+++ b/SmartyEngine.php
@@ -58,7 +58,6 @@ class SmartyEngine implements EngineInterface
     protected $loader;
     protected $parser;
     protected $plugins;
-    protected $registeredPlugins = array();
     protected $smarty;
 
     /**
@@ -582,7 +581,7 @@ class SmartyEngine implements EngineInterface
     protected function registerPlugin(PluginInterface $plugin)
     {
         // verify that plugin isn't registered yet. That would cause a SmartyException.
-        if (!in_array($plugin->getType() . '_' . $plugin->getName(), $this->registeredPlugins)) {
+        if (!isset($this->smarty->registered_plugins[$plugin->getType()][$plugin->getName()])) {
             $this->smarty->registerPlugin($plugin->getType(), $plugin->getName(), $plugin->getCallback());
             $this->registeredPlugins[] = $plugin->getType() . '_' . $plugin->getName();
         }


### PR DESCRIPTION
As you suggested earlier:

Improve "plugin already registered" verification by accessing the smarty plugin registry directly instead of keeping a second state in the bundle.

> Would be preferable to "ask" Smarty if the plugin is already registered to avoid keeping state in two places leading to inconsistency potentially. Not sure if Smarty provides this though.