### PR TITLE
extend security extension by csrf token manager and csrf token modifier

### DIFF
--- a/Resources/config/smarty.xml
+++ b/Resources/config/smarty.xml
@@ -61,6 +61,7 @@
         <service id="smarty.extension.security" class="%smarty.extension.security.class%" public="false">
             <tag name="smarty.extension" />
             <argument type="service" id="security.context" on-invalid="ignore" />
+            <argument type="service" id="security.csrf.token_manager" on-invalid="ignore" />
         </service>
 
         <service id="smarty.extension.expression" class="%smarty.extension.expression.class%" public="false">

--- a/Resources/config/smarty.xml
+++ b/Resources/config/smarty.xml
@@ -61,7 +61,8 @@
         <service id="smarty.extension.security" class="%smarty.extension.security.class%" public="false">
             <tag name="smarty.extension" />
             <argument type="service" id="security.context" on-invalid="ignore" />
-            <argument type="service" id="security.csrf.token_manager" on-invalid="ignore" />
+            <argument type="service" id="form.csrf_provider" on-invalid="null" />
+            <!--<argument type="service" id="security.csrf.token_manager" on-invalid="ignore" />-->
         </service>
 
         <service id="smarty.extension.expression" class="%smarty.extension.expression.class%" public="false">

--- a/Tests/Extension/SecurityExtensionTest.php
+++ b/Tests/Extension/SecurityExtensionTest.php
@@ -136,7 +136,7 @@ class SecurityExtensionTest extends TestCase
     {
         $csrfToken = $this->getMock('stdClass', array('getValue'));
         $csrfToken->expects($this->any())->method('getValue')->will($this->returnValue($value));
-        $csrfTokenManager = $this->getMock('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface');
+        $csrfTokenManager = $this->getMock('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface', array('getToken', 'refreshToken', 'removeToken', 'isTokenValid'));
         $csrfTokenManager->expects($this->any())->method('getToken')->will($this->returnValue($csrfToken));
 
         return $csrfTokenManager;

--- a/Tests/Extension/SecurityExtensionTest.php
+++ b/Tests/Extension/SecurityExtensionTest.php
@@ -31,6 +31,7 @@ use NoiseLabs\Bundle\SmartyBundle\Extension\SecurityExtension;
 use NoiseLabs\Bundle\SmartyBundle\Tests\TestCase;
 use Symfony\Component\Security\Core\SecurityContext;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\Security\Csrf\CsrfToken;
 
 /**
  * Test suite for the security extension.
@@ -118,10 +119,7 @@ class SecurityExtensionTest extends TestCase
 
     protected function createCsrfTokenManager($tokenId, $value)
     {
-        $csrfToken = $this->getMockBuilder('Symfony\Component\Security\Csrf\CsrfToken')
-            ->setConstructorArgs(array($tokenId, $value))
-            ->getMock();
-        $csrfToken->expects($this->any())->method('getValue')->will($this->returnValue($value));
+        $csrfToken = new CsrfToken($tokenId, $value);
         $csrfTokenManager = $this->getMock('Symfony\Component\Security\Csrf\CsrfTokenManagerInterface');
         $csrfTokenManager->expects($this->any())->method('getToken')->will($this->returnValue($csrfToken));
 


### PR DESCRIPTION
In twig templates a csrf token can be set with `{{ csrf_token('your_token_id') }}`.
The pull request adds this functionality through a modifier plugin `{'your_token_id'|csrf_token}`.

The functionality is required for using the symfony authentication with csrf protection. Therefore a csrf token with the id "authenticate" has to be set in the login form.

`{'authenticate'|csrf_token}`

Functionality was mainly ported from the form_extension (branch) to the security extension. Because the form extension branch wouldn't be finished soon and symfony itself handles the csrf functionality in a separate security component - independent from the form component.

I would be grateful if you could merge this PR to the master.