### PR TITLE
can pass null argument in AssetsExtension constructor

### DIFF
--- a/Extension/AssetsExtension.php
+++ b/Extension/AssetsExtension.php
@@ -48,7 +48,7 @@ class AssetsExtension extends AbstractExtension
     /**
      * Constructor.
      */
-    public function __construct(Packages $packages)
+    public function __construct(Packages $packages = null)
     {
         $this->packages = $packages;
     }


### PR DESCRIPTION
I got error in php 7.1 if my app have not symfony/asset component
```
Argument 1 passed to NoiseLabs\Bundle\SmartyBundle\Extension\AssetsExtension::__construct() must be an instance of Symfony\Component\Asset\Packages, null given, called in /var/www/pediatr-web/var/cache/dev/ContainerBZEYqDi/getTemplating_Engine_SmartyService.php on line 41
```
see https://stackoverflow.com/questions/14584145/cannot-pass-null-argument-when-using-type-hinting