### PR TITLE
BugFix for read in-memory cache

### DIFF
--- a/src/Loader/TemplateLoader.php
+++ b/src/Loader/TemplateLoader.php
@@ -71,8 +71,8 @@ class TemplateLoader
     {
         $templateId = $name instanceof TemplateReferenceInterface ? $name->getLogicalName() : $name;
 
-        if (isset($this->cache[$name])) {
-            return $this->cache[$name];
+        if (isset($this->cache[$templateId])) {
+            return $this->cache[$templateId];
         }
 
         $template = $name instanceof TemplateReferenceInterface ? $name : $this->defaultTemplateParser->parse($name);


### PR DESCRIPTION

I am getting the following error when invoking the `smarty:compile` command.
```shell
php bin/console smarty:compile
18:45:49 CRITICAL  [console] Error thrown while running command "smarty:compile". Message: "Illegal offset type in isset or empty" ["exception" => TypeError { …},"command" => "smarty:compile","message" => "Illegal offset type in isset or empty"]

In TemplateLoader.php line 77:

  Illegal offset type in isset or empty


smarty:compile [-h|--help] [-q|--quiet] [-v|vv|vvv|--verbose] [-V|--version] [--ansi] [--no-ansi] [-n|--no-interaction] [-e|--env ENV] [--no-debug] [--] <command> [<bundle>]
```

In the original code, some time the $name will be a object.


```php
return $this->cache[$templateId] = (string) $file;
```
Base on this idea,  the cache index should be $templateId.
So we should read cache from memory by $templateId instead of $name.

